### PR TITLE
Fix "Uncaught TypeError"

### DIFF
--- a/src/vue-resource-progressbar-interceptor.js
+++ b/src/vue-resource-progressbar-interceptor.js
@@ -78,7 +78,7 @@ const VueResourceProgressBarInterceptor = {
 
         // Finish progress bar some time later
         setTimeout(() => {
-          if (!response.ok) {
+          if (!response || !response.ok) {
             progress.fail();
             setComplete();
           }


### PR DESCRIPTION
This fixes Uncaught TypeError: Cannot read property 'ok' of undefined when trying to read the 'ok' property of the response object when it is undefined.

This seems to happen in the [next response callback](https://github.com/staskjs/vue-resource-progressbar-interceptor/blob/master/src/vue-resource-progressbar-interceptor.js#L81) when an earlier interceptor has failed to return the response object and it is thus undefined in the callback.

It is very easy for this plugin to gracefully handle that by checking that the response variable isn't falsy before trying to access the 'ok' property on it.

```js
        // Finish progress bar some time later
        setTimeout(function () {
          if (!response || !response.ok) {
            progress.fail();
            setComplete();
          }
```